### PR TITLE
Make _elem_cb accessible from derived classes

### DIFF
--- a/SndControl.h
+++ b/SndControl.h
@@ -319,7 +319,6 @@ protected:
   //! user supplied onInfoChange() and/or onValueChange() depending on mask.
   virtual void onElemEvent(unsigned mask) =0;
 
-private:
   //! \brief ALSA hcontrol element callback.
   static int _elem_cb(snd_hctl_elem_t *elem, unsigned int mask);
   


### PR DESCRIPTION
This PR fixes a compile issue caused by the `_elem_cb` declared as private but accessed from the derived class `SndAnyControl`.